### PR TITLE
Implement MpvNode (arrays and maps)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,9 @@ pub mod mpv_format {
     pub use libmpv_sys::mpv_format_MPV_FORMAT_DOUBLE as Double;
     pub use libmpv_sys::mpv_format_MPV_FORMAT_FLAG as Flag;
     pub use libmpv_sys::mpv_format_MPV_FORMAT_INT64 as Int64;
+    pub use libmpv_sys::mpv_format_MPV_FORMAT_NODE as Node;
+    pub use libmpv_sys::mpv_format_MPV_FORMAT_NODE_ARRAY as Array;
+    pub use libmpv_sys::mpv_format_MPV_FORMAT_NODE_MAP as Map;
     pub use libmpv_sys::mpv_format_MPV_FORMAT_NONE as None;
     pub use libmpv_sys::mpv_format_MPV_FORMAT_OSD_STRING as OsdString;
     pub use libmpv_sys::mpv_format_MPV_FORMAT_STRING as String;

--- a/src/mpv/errors.rs
+++ b/src/mpv/errors.rs
@@ -47,6 +47,7 @@ impl From<NulError> for Error {
         Error::Null
     }
 }
+
 impl From<Utf8Error> for Error {
     fn from(_other: Utf8Error) -> Error {
         Error::InvalidUtf8

--- a/src/mpv/events.rs
+++ b/src/mpv/events.rs
@@ -245,7 +245,8 @@ impl<'parent> EventContext<'parent> {
             mpv_event_id::None => None,
             mpv_event_id::Shutdown => Some(Ok(Event::Shutdown)),
             mpv_event_id::LogMessage => {
-                let log_message = unsafe { *(event.data as *mut libmpv_sys::mpv_event_log_message) };
+                let log_message =
+                    unsafe { *(event.data as *mut libmpv_sys::mpv_event_log_message) };
 
                 let prefix = unsafe { mpv_cstr_to_str!(log_message.prefix) };
                 Some(prefix.and_then(|prefix| {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -160,31 +160,27 @@ fn node_map() -> Result<()> {
 
     thread::sleep(Duration::from_millis(250));
     let audio_params: MpvNode = mpv.get_property("audio-params")?;
+    let params: HashMap<&str, MpvNode> =
+        audio_params.to_map().ok_or_else(|| Error::Null)?.collect();
 
-    if let MpvNodeValue::Map(data) = audio_params.value()? {
-        let params: HashMap<&str, MpvNode> = data.collect();
+    assert_eq!(params.len(), 5);
 
-        assert_eq!(params.len(), 5);
+    let format = params.get("format").unwrap().value()?;
+    assert!(matches!(format, MpvNodeValue::String("s16")));
 
-        let format = params.get("format").unwrap().value()?;
-        assert!(matches!(format, MpvNodeValue::String("s16")));
+    let samplerate = params.get("samplerate").unwrap().value()?;
+    assert!(matches!(samplerate, MpvNodeValue::Int64(48_000)));
 
-        let samplerate = params.get("samplerate").unwrap().value()?;
-        assert!(matches!(samplerate, MpvNodeValue::Int64(48_000)));
+    let channels = params.get("channels").unwrap().value()?;
+    assert!(matches!(channels, MpvNodeValue::String("mono")));
 
-        let channels = params.get("channels").unwrap().value()?;
-        assert!(matches!(channels, MpvNodeValue::String("mono")));
+    let hr_channels = params.get("hr-channels").unwrap().value()?;
+    assert!(matches!(hr_channels, MpvNodeValue::String("mono")));
 
-        let hr_channels = params.get("hr-channels").unwrap().value()?;
-        assert!(matches!(hr_channels, MpvNodeValue::String("mono")));
+    let channel_count = params.get("channel-count").unwrap().value()?;
+    assert!(matches!(channel_count, MpvNodeValue::Int64(1)));
 
-        let channel_count = params.get("channel-count").unwrap().value()?;
-        assert!(matches!(channel_count, MpvNodeValue::Int64(1)));
-
-        Ok(())
-    } else {
-        Err(Error::Raw(mpv_error::UnknownFormat))
-    }
+    Ok(())
 }
 
 #[test]
@@ -199,22 +195,17 @@ fn node_array() -> Result<()> {
 
     thread::sleep(Duration::from_millis(250));
     let playlist: MpvNode = mpv.get_property("playlist")?;
+    let items: Vec<MpvNode> = playlist.to_array().ok_or_else(|| Error::Null)?.collect();
 
-    match playlist.value()? {
-        MpvNodeValue::Array(data) => {
-            let items: Vec<MpvNode> = data.collect();
-            assert_eq!(items.len(), 1);
+    assert_eq!(items.len(), 1);
+    let track: HashMap<&str, MpvNode> = items[0].to_map().ok_or_else(|| Error::Null)?.collect();
 
-            match items[0].value()? {
-                MpvNodeValue::Map(data) => {
-                    let track: HashMap<&str, MpvNode> = data.collect();
-                    let filename = track.get("filename").unwrap().value()?;
-                    assert!(matches!(filename, MpvNodeValue::String("test-data/speech_12kbps_mb.wav")));
-                    Ok(())
-                }
-                _ => Err(Error::Raw(mpv_error::UnknownFormat)),
-            }
-        }
-        _ => Err(Error::Raw(mpv_error::UnknownFormat)),
-    }
+    let filename = track.get("filename").unwrap().value()?;
+
+    assert!(matches!(
+        filename,
+        MpvNodeValue::String("test-data/speech_12kbps_mb.wav")
+    ));
+
+    Ok(())
 }


### PR DESCRIPTION
I thought I'd take a stab at implementing `MpvNode`. It's very rough but it seems to return the expected keys.

Possible issues:

1. ~I cast between `i32` and `usize`~
2. ~Should I be using `MpvStr<'a>` as the key to the `HashMap`~
3. ~Is there a better way to construct the `Vec`/`HashMap` (for `Array` and `Map` respectively)?~
4. ~Is `try_into` the correct approach here?~