### PR TITLE
change `Error::Loadfiles::error` type from `Rc` to `Box`

### DIFF
--- a/src/mpv.rs
+++ b/src/mpv.rs
@@ -698,7 +698,7 @@ impl Mpv {
             if let Err(err) = ret {
                 return Err(Error::Loadfiles {
                     index: i,
-                    error: ::std::rc::Rc::new(err),
+                    error: ::std::boxed::Box::new(err),
                 });
             }
         }

--- a/src/mpv/errors.rs
+++ b/src/mpv/errors.rs
@@ -16,7 +16,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-use std::{error, ffi::NulError, fmt, os::raw as ctype, rc::Rc, str::Utf8Error};
+use std::{error, ffi::NulError, fmt, os::raw as ctype, str::Utf8Error};
 
 #[allow(missing_docs)]
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -25,7 +25,7 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 pub enum Error {
     Loadfiles {
         index: usize,
-        error: Rc<Error>,
+        error: Box<Error>,
     },
     VersionMismatch {
         linked: ctype::c_ulong,


### PR DESCRIPTION
change the type for `Error::Loadfiles { error }` from an `Rc` to a `Box`

## context

i'm writing a music player using this library to play music via mpv

```rs
/// wrapper struct for mpv
pub struct Player(Mpv);
```

and i want to create a wrapper error enum and pull the inner error out of `libmpv::Error::Loadfiles`.

```rs
#[derive(Debug, thiserror::Error)]
pub enum PlayerError {
    #[error("invalid utf8")]
    InvalidUtf8,
    #[error("null error")]
    Null,
    // ...
}
```

but when want to `impl From<libmpv::Error>` for the enum, i have to do some annoying `Rc` fuckery to get at the inner value, even though the `Rc` is only created once and never cloned

```rs
impl From<libmpv::Error> for PlayerError {
    fn from(value: libmpv::Error) -> Self {
        match value {
            libmpv::Error::Loadfiles { index: _, error } => match Rc::into_inner(error) {
                Some(error) => PlayerError::from(error),
                // why?
                None => unreachable!()
            },
            // ...
        }
    }
}
```

if you were to change the type into a `Box` everything works the same, but actually using the error type is a lot less annyoing to work with

```rs
impl From<libmpv::Error> for PlayerError {
    fn from(value: libmpv::Error) -> Self {
        match value {
            libmpv::Error::Loadfiles { index: _, error } => PlayerError::from(*error),
            // ...
        }
    }
}
```

i couldn't find a reason for why the error type uses an `Rc` instead of a `Box`, but the `Rc` was added in commit 53b430d after a comment, that was added in commit 9043418

<br />

as an aside, the Rc prevents the error to be used with the `anyhow` or `color_eyre` crate, as the `anyhow::Error` result has type bounds for `Send` and `Sync`

```rs
impl Player {
    pub fn new() -> anyhow::Result<Self> { // same with color_eyre::Result
        let mpv = Mpv::new()?; // `std::rc::Rc<libmpv::Error>` cannot be sent between threads safely
        mpv.set_property("vo", "null")?; // `std::rc::Rc<libmpv::Error>` cannot be sent between threads safely

        let player = Player(mpv);
        Ok(player)
    }
}
```